### PR TITLE
Add unit tests for AuthService role-based authorization using AppUserRoles

### DIFF
--- a/Drosy.Application/UseCases/Authentication/Interfaces/IAuthService.cs
+++ b/Drosy.Application/UseCases/Authentication/Interfaces/IAuthService.cs
@@ -1,6 +1,7 @@
 ﻿using Drosy.Application.UsesCases.Authentication.DTOs;
 using Drosy.Application.UsesCases.Users.DTOs;
 using Drosy.Domain.Shared.ResultPattern;
+using System.Security.Claims;
 
 namespace Drosy.Application.UsesCases.Authentication.Interfaces
 {
@@ -8,5 +9,7 @@ namespace Drosy.Application.UsesCases.Authentication.Interfaces
     {
         Task<Result<AuthModel>> LoginAsync(UserLoginDTO user);
         Task<Result<AuthModel>> RefreshTokenAsync(string tokenString);
+
+        bool IsAuthorized(ClaimsPrincipal user, string requiredRole);
     }
 }

--- a/Drosy.Application/UseCases/Authentication/Services/AuthService.cs
+++ b/Drosy.Application/UseCases/Authentication/Services/AuthService.cs
@@ -5,6 +5,7 @@ using Drosy.Application.Interfaces.Common;
 using Drosy.Domain.Interfaces.Repository;
 using Drosy.Domain.Shared.ResultPattern;
 using Drosy.Domain.Shared.ResultPattern.ErrorComponents;
+using System.Security.Claims;
 
 namespace Drosy.Application.UsesCases.Authentication.Services
 {
@@ -42,6 +43,10 @@ namespace Drosy.Application.UsesCases.Authentication.Services
             return Result.Success(tokenResult.Value);
         }
 
+        public bool IsAuthorized(ClaimsPrincipal user, string requiredRole)
+        {
+            return user.IsInRole(requiredRole);
+        }
         public async Task<Result<AuthModel>> RefreshTokenAsync(string tokenString)
         {
             if (string.IsNullOrEmpty(tokenString)) return Result.Failure<AuthModel>(Error.NullValue);

--- a/Drosy.Tests/Application/Auth/AuthorizationServiceTests.cs
+++ b/Drosy.Tests/Application/Auth/AuthorizationServiceTests.cs
@@ -1,0 +1,51 @@
+﻿using Xunit;
+using System.Security.Claims;
+using Drosy.Domain.Shared.System;
+using Drosy.Application.UsesCases.Authentication.Services;
+using Drosy.Application.Interfaces.Common;
+using Drosy.Domain.Interfaces.Repository;
+using Moq;
+
+namespace Drosy.Tests.Application.Auth
+{
+    public class AuthorizationServiceTests
+    {
+        private readonly Mock<IJwtService> _jwtServiceMock;
+        private readonly Mock<IAppUserRepository> _userRepoMock;
+        private readonly Mock<IIdentityService> _identityServiceMock;
+        private readonly AuthService _authService;
+
+        public AuthorizationServiceTests()
+        {
+            _jwtServiceMock = new Mock<IJwtService>();
+            _userRepoMock = new Mock<IAppUserRepository>();
+            _identityServiceMock = new Mock<IIdentityService>();
+
+            _authService = new AuthService(
+                _jwtServiceMock.Object,
+                _userRepoMock.Object,
+                _identityServiceMock.Object
+            );
+        }
+
+        [Theory]
+        [InlineData(AppUserRoles.Admin, AppUserRoles.Admin, true)]
+        [InlineData(AppUserRoles.Receptionist, AppUserRoles.Admin, false)]
+        [InlineData(AppUserRoles.Student, AppUserRoles.Admin, false)]
+        [InlineData(AppUserRoles.Student, AppUserRoles.Student, true)]
+        public void IsAuthorized_ShouldMatchExpected(string userRole, string requiredRole, bool expected)
+        {
+            // Arrange
+            var claims = new List<Claim> { new Claim(ClaimTypes.Role, userRole) };
+            var identity = new ClaimsIdentity(claims, "TestAuthType");
+            var user = new ClaimsPrincipal(identity);
+
+            // Act
+            var result = _authService.IsAuthorized(user, requiredRole);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+    }
+
+}

--- a/Drosy.Tests/Drosy.Tests.csproj
+++ b/Drosy.Tests/Drosy.Tests.csproj
@@ -8,14 +8,22 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.2"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-        <PackageReference Include="xunit" Version="2.9.2"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2"/>
+        <PackageReference Include="coverlet.collector" Version="6.0.2" />
+        <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+      <ProjectReference Include="..\Drosy.Application\Drosy.Application.csproj" />
+      <ProjectReference Include="..\Drosy.Domain\Drosy.Domain.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added unit tests to validate role-based access control in AuthService using the predefined roles in AppUserRoles. This ensures that authorization logic behaves as expected across different user roles (Admin, Receptionist, Student), aligning with clean architecture principles.

Changes Introduced

🧱 Centralized role constants in Drosy.Domain.Shared.System.AppUserRoles

✅ Unit tests for AuthService.IsAuthorized() covering multiple role scenarios

🧰 Mocks created for dependencies: IJwtService, IAppUserRepository, IIdentityService

📁 Tests organized under Tests/Application/Auth/AuthorizationServiceTests.cs

📦 Followed naming conventions for clarity and test discovery

🧪 Used [Theory] and [InlineData] for concise multi-role validation