### PR TITLE
feat(validation): ensure expected date is not in the past

### DIFF
--- a/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.Designer.cs
+++ b/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.Designer.cs
@@ -61,6 +61,15 @@ namespace Drosy.Domain.Shared.ErrorComponents.Sesstions.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to يجب أن لا يكون التاريخ المتوقع في الماضي..
+        /// </summary>
+        internal static string Error_Session_ExpectedDateInThePast {
+            get {
+                return ResourceManager.GetString("Error_Session_ExpectedDateInThePast", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to النطاق الزمني المحدد للجلسة غير صالح..
         /// </summary>
         internal static string Error_Session_InvalidTimeRange {

--- a/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.ar.resx
+++ b/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.ar.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Error_Session_ExpectedDateInThePast" xml:space="preserve">
+    <value>يجب أن لا يكون التاريخ المتوقع في الماضي.</value>
+  </data>
   <data name="Error_Session_InvalidTimeRange" xml:space="preserve">
     <value>النطاق الزمني المحدد للجلسة غير صالح.</value>
   </data>

--- a/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.en.resx
+++ b/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.en.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Error_Session_ExpectedDateInThePast" xml:space="preserve">
+    <value>The expected date must not be in the past.</value>
+  </data>
   <data name="Error_Session_InvalidTimeRange" xml:space="preserve">
     <value>The selected time range for the session is not valid.</value>
   </data>

--- a/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.resx
+++ b/Drosy.Domain/Shared/ErrorComponents/Sesstions/Resources/ErrorMessages.Session.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="Error_Session_ExpectedDateInThePast" xml:space="preserve">
+    <value>يجب أن لا يكون التاريخ المتوقع في الماضي.</value>
+  </data>
   <data name="Error_Session_InvalidTimeRange" xml:space="preserve">
     <value>النطاق الزمني المحدد للجلسة غير صالح.</value>
   </data>

--- a/Drosy.Domain/Shared/ErrorComponents/Sesstions/SessionErrorCodes.cs
+++ b/Drosy.Domain/Shared/ErrorComponents/Sesstions/SessionErrorCodes.cs
@@ -12,6 +12,6 @@
         public const string InvalidTimeRange = "Error_Session_InvalidTimeRange";
         public const string PlanNotFound = "Error_Session_PlanNotFound";
         public const string SessionNotFound = "Error_Session_SessionNotFound";
-
+        public const string ExpectedDateInThePast = "Error_Session_ExpectedDateInThePast";
     }
 }

--- a/Drosy.Domain/Shared/ErrorComponents/Sesstions/SessionErrors.cs
+++ b/Drosy.Domain/Shared/ErrorComponents/Sesstions/SessionErrors.cs
@@ -11,7 +11,9 @@
         public static AppError TitleRequired => new(SessionErrorCodes.TitleRequired);
         public static AppError InvalidTimeRange => new(SessionErrorCodes.InvalidTimeRange);
         public static AppError PlanNotFound => new(SessionErrorCodes.PlanNotFound);
-        public static AppError SessionNotFound => new(SessionErrorCodes.SessionNotFound); 
+        public static AppError SessionNotFound => new(SessionErrorCodes.SessionNotFound);
+        public static AppError ExpectedDateInThePast => new(SessionErrorCodes.ExpectedDateInThePast);
+
 
     }
 }

--- a/Drosy.Infrastructure/Validators/SessionValidatiors/AddSessionValidator.cs
+++ b/Drosy.Infrastructure/Validators/SessionValidatiors/AddSessionValidator.cs
@@ -21,7 +21,7 @@ namespace Drosy.Infrastructure.Validators.SessionValidatiors
 
             // 📌 Expected Date must not be in the past
             RuleFor(x => x.ExcepectedDate.Date)
-                .GreaterThanOrEqualTo(DateTime.Today).WithMessage(SessionErrors.OutsideExpectedDate.Message);
+                .GreaterThanOrEqualTo(DateTime.Today).WithMessage(SessionErrors.ExpectedDateInThePast.Message);
 
             // 📌 StartTime must be before EndTime
             RuleFor(x => x)


### PR DESCRIPTION
Added FluentValidation rule to enforce that the session's expected date (ExcepectedDate) must be today or later. Linked error message and code to SessionErrorCodes.ExpectedDateInThePast for consistency.