### PR TITLE
feat(session): annotate SessionsController and add Notes support to S…

### DIFF
--- a/Drosy.Api/Controllers/SessionsController.cs
+++ b/Drosy.Api/Controllers/SessionsController.cs
@@ -27,8 +27,19 @@ namespace Drosy.Api.Controllers
         /// </summary>
         /// <param name="id">The unique session identifier.</param>
         /// <param name="ct">A cancellation token.</param>
-        /// <returns>Session information or error response.</returns>
+        /// <returns>
+        /// 200 OK if the session is found.  
+        /// 400 Bad Request if <paramref name="id"/> is less than 1.  
+        /// 404 Not Found if the session does not exist.  
+        /// 422 Unprocessable Entity for domain-related validation errors.  
+        /// 500 Internal Server Error for unexpected exceptions.
+        /// </returns>
         [HttpGet("{id:int}", Name = "GetSessionByIdAsync")]
+        [ProducesResponseType(typeof(ApiResponse<SessionDTO>), 200)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 422)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 500)]
         public async Task<IActionResult> GetByIdAsync(int id, CancellationToken ct)
         {
             if (id < 1)
@@ -63,9 +74,18 @@ namespace Drosy.Api.Controllers
         /// </summary>
         /// <param name="dto">Session data transfer object.</param>
         /// <param name="ct">A cancellation token.</param>
-        /// <returns>Created session details or error.</returns>
+        /// <returns>
+        /// 201 Created on successful session addition.  
+        /// 400 Bad Request if <paramref name="dto"/> is null or invalid.  
+        /// 422 Unprocessable Entity for domain validation failures.  
+        /// 500 Internal Server Error on unexpected exceptions.
+        /// </returns>
         [HttpPost(Name = "CreateSessionAsync")]
-        public async Task<IActionResult> CreateAsync([FromBody] AddSessionDTO dto, CancellationToken ct)
+        [ProducesResponseType(typeof(ApiResponse<SessionDTO>), 201)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 422)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 500)]
+        public async Task<IActionResult> CreateAsync([FromBody] CreateSessionDTO dto, CancellationToken ct)
         {
             if (dto == null)
             {
@@ -95,6 +115,59 @@ namespace Drosy.Api.Controllers
             }
         }
 
+
+        /// <summary>
+        /// Reschedules an existing session.
+        /// </summary>
+        /// <param name="sessionId">The identifier of the session to update.</param>
+        /// <param name="dto">Reschedule session data transfer object.</param>
+        /// <param name="ct">A cancellation token.</param>
+        /// <returns>
+        /// 200 OK on successful rescheduling.  
+        /// 400 Bad Request if <paramref name="sessionId"/> is less than 1 or input DTO is invalid.  
+        /// 404 Not Found if the session does not exist.  
+        /// 422 Unprocessable Entity for domain validation failures.  
+        /// 500 Internal Server Error on exceptions.
+        /// </returns>
+        [HttpPut("{sessionId:int}", Name = "RescheduleSessionAsync")]
+        [ProducesResponseType(typeof(ApiResponse<SessionDTO>), 200)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 400)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 404)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 422)]
+        [ProducesResponseType(typeof(ApiResponse<object>), 500)]
+        public async Task<IActionResult> RescheduleAsync(int sessionId, [FromBody] RescheduleSessionDTO dto, CancellationToken ct)
+        {
+            if (sessionId < 1)
+            {
+                var error = new ApiError("sessionId", ErrorMessageResourceRepository.GetMessage(CommonErrors.Invalid.Message, AppError.CurrentLanguage));
+                return ApiResponseFactory.BadRequestResponse("sessionId", "Invalid session ID.", error.Message);
+            }
+
+            if (dto == null)
+            {
+                var error = new ApiError("dto", ErrorMessageResourceRepository.GetMessage(CommonErrors.NullValue.Message, AppError.CurrentLanguage));
+                return ApiResponseFactory.BadRequestResponse("dto", "Invalid reschedule data.", error.Message);
+            }
+
+            try
+            {
+                var result = await _sessionService.RescheduleAsync(sessionId, dto, ct);
+
+                if (result.IsFailure)
+                {
+                    return ApiResponseFactory.FromFailure(result, nameof(RescheduleAsync), "Session");
+                }
+
+                return ApiResponseFactory.SuccessResponse(
+                    result.Value,
+                    "Session rescheduled successfully."
+                );
+            }
+            catch (Exception ex)
+            {
+                return ApiResponseFactory.FromException(ex);
+            }
+        }
         #endregion
     }
 }

--- a/Drosy.Api/Extensions/DependencyInjection/DbInitializerExtention.cs
+++ b/Drosy.Api/Extensions/DependencyInjection/DbInitializerExtention.cs
@@ -11,7 +11,7 @@ namespace Drosy.Api.Extensions.DependencyInjection
             return services;
         }
 
-        public static void setupDBInitializer(this IApplicationBuilder app)
+        public static void SetupDbInitializer(this IApplicationBuilder app)
         {
             using (var scope = app.ApplicationServices.CreateScope())
             {

--- a/Drosy.Application/UseCases/Sessions/DTOs/CreateSessionDTO.cs
+++ b/Drosy.Application/UseCases/Sessions/DTOs/CreateSessionDTO.cs
@@ -1,11 +1,12 @@
 ﻿namespace Drosy.Application.UseCases.Sessions.DTOs;
 
-public class AddSessionDTO
+public class CreateSessionDTO
 {
     public int PlanId { get; set; }
     public string Title { get; set; } = null!;
     public DateTime ExcepectedDate { get; set; }
     public DateTime StartTime { get; set; }
     public DateTime EndTime { get; set; }
+    public string? Notes { get; set; }
 
 }

--- a/Drosy.Application/UseCases/Sessions/DTOs/RescheduleSessionDTO.cs
+++ b/Drosy.Application/UseCases/Sessions/DTOs/RescheduleSessionDTO.cs
@@ -1,0 +1,9 @@
+﻿namespace Drosy.Application.UseCases.Sessions.DTOs;
+
+public class RescheduleSessionDTO
+{
+    public DateTime NewDate { get; set; }
+    public DateTime NewStartTime { get; set; }
+    public DateTime NewEndTime { get; set; }
+}
+

--- a/Drosy.Application/UseCases/Sessions/DTOs/SessionDTO.cs
+++ b/Drosy.Application/UseCases/Sessions/DTOs/SessionDTO.cs
@@ -9,8 +9,10 @@ public class SessionDTO
     public DateTime ExcepectedDate { get; set; }
     public DateTime StartTime { get; set; }
     public DateTime EndTime { get; set; }
+    public string? Notes { get; set; }
 
     #region Navigations
     public PlanDto Plan { get; set; } = null!;
     #endregion
 }
+

--- a/Drosy.Application/UseCases/Sessions/Interfaces/ISessionService.cs
+++ b/Drosy.Application/UseCases/Sessions/Interfaces/ISessionService.cs
@@ -1,15 +1,45 @@
 ﻿using Drosy.Application.UseCases.Sessions.DTOs;
 using Drosy.Domain.Shared.ApplicationResults;
 
-namespace Drosy.Application.UseCases.Sessions.Interfaces;
-
-public interface ISessionService
+namespace Drosy.Application.UseCases.Sessions.Interfaces
 {
-    #region Read
-    public Task<Result<SessionDTO>> GetByIdAsync(int id, CancellationToken cancellationToken);
-    #endregion
+    /// <summary>
+    /// Defines the core operations related to session management including retrieval,
+    /// creation, and rescheduling with validation and result encapsulation.
+    /// </summary>
+    public interface ISessionService
+    {
+        #region Read
 
-    #region Write 
-    public Task<Result<SessionDTO>> CreateAsync(AddSessionDTO sessionDTO, CancellationToken cancellationToken);
-    #endregion
+        /// <summary>
+        /// Retrieves a session by its unique identifier.
+        /// </summary>
+        /// <param name="id">The ID of the session.</param>
+        /// <param name="cancellationToken">Token for cancelling the asynchronous operation.</param>
+        /// <returns>A result containing the session DTO if found, otherwise an error result.</returns>
+        Task<Result<SessionDTO>> GetByIdAsync(int id, CancellationToken cancellationToken);
+
+        #endregion
+
+        #region Write
+
+        /// <summary>
+        /// Creates a new session using the provided session data.
+        /// </summary>
+        /// <param name="sessionDTO">The DTO containing session creation details.</param>
+        /// <param name="cancellationToken">Token for cancelling the asynchronous operation.</param>
+        /// <returns>A result containing the newly created session DTO or an error result.</returns>
+        Task<Result<SessionDTO>> CreateAsync(CreateSessionDTO sessionDTO, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Reschedules an existing session in case of emergencies. Ensures no timing conflicts or plan disruptions.
+        /// </summary>
+        /// <param name="sessionId">The ID of the session to reschedule.</param>
+        /// <param name="dto">DTO containing the new date, time, and reason for rescheduling.</param>
+        /// <param name="cancellationToken">Token for cancelling the asynchronous operation.</param>
+        /// <returns>A result containing the updated session DTO or an appropriate failure message.</returns>
+        Task<Result<SessionDTO>> RescheduleAsync(int sessionId, RescheduleSessionDTO dto, CancellationToken cancellationToken);
+
+        #endregion
+    }
 }

--- a/Drosy.Domain/Entities/Session.cs
+++ b/Drosy.Domain/Entities/Session.cs
@@ -7,6 +7,7 @@
         public DateTime ExcepectedDate { get; set; } 
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
+        public string? Notes { get; set; }
 
         #region Navigations
         public Plan Plan { get; set; } = null!;

--- a/Drosy.Domain/Interfaces/Repository/ISessionRepository.cs
+++ b/Drosy.Domain/Interfaces/Repository/ISessionRepository.cs
@@ -1,59 +1,72 @@
 ﻿using Drosy.Domain.Entities;
 using Drosy.Domain.Interfaces.Common.Repository;
+using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 
 namespace Drosy.Domain.Interfaces.Repository
 {
     /// <summary>
-    /// Defines data access operations for Session entities.
+    /// Defines data access operations for session entities.
     /// </summary>
     public interface ISessionRepository : IRepository<Session>
     {
-        #region 🔍 Single Retrieval
+        #region Read Operations
 
         /// <summary>
         /// Retrieves a session entity by its unique identifier.
         /// </summary>
-        /// <param name="id">The unique identifier of the session.</param>
+        /// <param name="id">The session's unique identifier.</param>
         /// <param name="cancellationToken">Token to cancel the async operation.</param>
-        /// <returns>The session entity if found; otherwise, null.</returns>
+        /// <returns>The matching session if found; otherwise, null.</returns>
         Task<Session?> GetByIdAsync(int id, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves all sessions scheduled for a given date and plan.
+        /// </summary>
+        /// <param name="date">Target date.</param>
+        /// <param name="planId">Associated plan ID.</param>
+        /// <param name="cancellationToken">Token to cancel the async operation.</param>
+        /// <returns>A list of sessions scheduled for the specified date and plan.</returns>
+        Task<IEnumerable<Session>> GetByDateAndPlanAsync(DateTime date, int planId, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Checks whether any session overlaps with a specified time range on a given date and plan.
+        /// </summary>
+        /// <param name="date">Date to check.</param>
+        /// <param name="planId">Associated plan ID.</param>
+        /// <param name="startTime">Proposed start time.</param>
+        /// <param name="endTime">Proposed end time.</param>
+        /// <param name="cancellationToken">Token to cancel the async operation.</param>
+        /// <returns>True if an overlap is found; otherwise, false.</returns>
+        Task<bool> ExistsAsync(DateTime date, int planId, DateTime startTime, DateTime endTime, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Checks whether any session overlaps with a specified time range on a given date and plan,
+        /// excluding the session with the provided identifier.
+        /// </summary>
+        /// <param name="excludeSessionId">Session ID to exclude from the check.</param>
+        /// <param name="date">Date to check.</param>
+        /// <param name="startTime">Proposed start time.</param>
+        /// <param name="endTime">Proposed end time.</param>
+        /// <param name="cancellationToken">Token to cancel the async operation.</param>
+        /// <returns>True if another overlapping session exists; otherwise, false.</returns>
+        Task<bool> ExistsAsync(int excludeSessionId, DateTime date, DateTime startTime, DateTime endTime,  CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Checks whether any session overlaps with a specified time range on a given date, regardless of plan.
+        /// </summary>
+        /// <param name="date">Date to check.</param>
+        /// <param name="startTime">Proposed start time.</param>
+        /// <param name="endTime">Proposed end time.</param>
+        /// <param name="cancellationToken">Token to cancel the async operation.</param>
+        /// <returns>True if an overlap is found; otherwise, false.</returns>
+        Task<bool> ExistsAsync(DateTime date, DateTime startTime, DateTime endTime, CancellationToken cancellationToken);
 
         #endregion
 
-        #region 📅 Session Queries
-
-        /// <summary>
-        /// Retrieves all sessions scheduled for a specific date and plan.
-        /// </summary>
-        /// <param name="date">The target date to filter sessions.</param>
-        /// <param name="planId">The associated plan identifier.</param>
-        /// <param name="cancellationToken">Token to cancel the async operation.</param>
-        /// <returns>A list of matching session entities.</returns>
-        Task<IEnumerable<Session>> GetSessionsByDateAndPlanAsync(DateTime date, int planId, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Checks whether any session overlaps with a given time range for a specific date and plan.
-        /// </summary>
-        /// <param name="date">The date to check for overlapping sessions.</param>
-        /// <param name="planId">The associated plan identifier.</param>
-        /// <param name="startTime">The proposed start time of the session.</param>
-        /// <param name="endTime">The proposed end time of the session.</param>
-        /// <param name="cancellationToken">Token to cancel the async operation.</param>
-        /// <returns>True if an overlapping session exists; otherwise, false.</returns>
-        Task<bool> SessionExistsAsync(DateTime date, int planId, DateTime startTime, DateTime endTime, CancellationToken cancellationToken);
-
-        /// <summary>
-        /// Checks whether any session overlaps with a given time range for a specific date.
-        /// </summary>
-        /// <param name="date">The date to check for overlapping sessions.</param>
-        /// <param name="startTime">The proposed start time of the session.</param>
-        /// <param name="endTime">The proposed end time of the session.</param>
-        /// <param name="cancellationToken">Token to cancel the async operation.</param>
-        /// <returns>True if an overlapping session exists; otherwise, false.</returns>
-        Task<bool> SessionExistsAsync(DateTime date, DateTime startTime, DateTime endTime, CancellationToken cancellationToken);
+        #region Write Operations
 
         #endregion
     }

--- a/Drosy.Infrastructure/Mapping/SesstionsConfigs/SessionMappingConfig.cs
+++ b/Drosy.Infrastructure/Mapping/SesstionsConfigs/SessionMappingConfig.cs
@@ -1,4 +1,5 @@
-﻿using Drosy.Application.UseCases.Sessions.DTOs;
+﻿using Drosy.Application.UseCases.Plans.DTOs;
+using Drosy.Application.UseCases.Sessions.DTOs;
 using Drosy.Domain.Entities;
 using Mapster;
 
@@ -8,22 +9,30 @@ namespace Drosy.Infrastructure.Mapping.SessionConfigs
     {
         public void Register(TypeAdapterConfig config)
         {
-            // DTO ➜ Entity
-            config.NewConfig<AddSessionDTO, Session>()
+            // CreateSessionDTO → Session
+            config.NewConfig<CreateSessionDTO, Session>()
                 .Map(dest => dest.Title, src => src.Title.Trim())
                 .Map(dest => dest.PlanId, src => src.PlanId)
                 .Map(dest => dest.ExcepectedDate, src => src.ExcepectedDate)
                 .Map(dest => dest.StartTime, src => src.StartTime)
                 .Map(dest => dest.EndTime, src => src.EndTime);
 
-            // Entity ➜ DTO
-            config.NewConfig<Session, SessionDTO>()
+            // RescheduleSessionDTO → Session
+            config.NewConfig<RescheduleSessionDTO, Session>()
+                .Map(dest => dest.ExcepectedDate, src => src.NewDate)
+                .Map(dest => dest.StartTime, src => src.NewStartTime)
+                .Map(dest => dest.EndTime, src => src.NewEndTime);
+
+            // Session → SessionDTO
+            TypeAdapterConfig<Session, SessionDTO>
+                .NewConfig()
                 .Map(dest => dest.Id, src => src.Id)
-                .Map(dest => dest.Plan.Id, src => src.PlanId)
                 .Map(dest => dest.Title, src => src.Title)
                 .Map(dest => dest.ExcepectedDate, src => src.ExcepectedDate)
                 .Map(dest => dest.StartTime, src => src.StartTime)
-                .Map(dest => dest.EndTime, src => src.EndTime);
+                .Map(dest => dest.EndTime, src => src.EndTime)
+                .Map(dest => dest.Notes, src => src.Notes)
+                .Map(dest => dest.Plan, src => src.Plan.Adapt<PlanDto>());
         }
     }
 }

--- a/Drosy.Infrastructure/Migrations/20250725195032_add-sessiontable-notes-column.Designer.cs
+++ b/Drosy.Infrastructure/Migrations/20250725195032_add-sessiontable-notes-column.Designer.cs
@@ -4,6 +4,7 @@ using Drosy.Infrastructure.Persistence.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Drosy.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250725195032_add-sessiontable-notes-column")]
+    partial class addsessiontablenotescolumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Drosy.Infrastructure/Migrations/20250725195032_add-sessiontable-notes-column.cs
+++ b/Drosy.Infrastructure/Migrations/20250725195032_add-sessiontable-notes-column.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Drosy.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class addsessiontablenotescolumn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Notes",
+                table: "Sessions",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Notes",
+                table: "Sessions");
+        }
+    }
+}

--- a/Drosy.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/Drosy.Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -22,10 +22,14 @@ namespace Drosy.Infrastructure.Persistence.Configurations
                 .IsRequired();
 
             builder.Property(x => x.StartTime)
-            .IsRequired();
+                .IsRequired();
 
             builder.Property(x => x.EndTime)
-            .IsRequired();
+                .IsRequired();
+
+            builder.Property(x => x.Notes)
+                .IsRequired(false);
+
 
             // Relationships
             builder.HasOne(x => x.Plan)

--- a/Drosy.Infrastructure/Validators/SessionValidatiors/CreateSessionValidator.cs
+++ b/Drosy.Infrastructure/Validators/SessionValidatiors/CreateSessionValidator.cs
@@ -6,22 +6,25 @@ using Drosy.Domain.Shared.ErrorComponents.Validation;
 
 namespace Drosy.Infrastructure.Validators.SessionValidatiors
 {
-    public class AddSessionValidator : AbstractValidator<AddSessionDTO>
+    public class CreateSessionValidator : AbstractValidator<CreateSessionDTO>
     {
-        public AddSessionValidator()
+        public CreateSessionValidator()
         {
             // 📌 Title validation
             RuleFor(x => x.Title)
                 .NotEmpty().WithMessage(SessionErrors.TitleRequired.Message)
-                .MaximumLength(TextValidationRules.MaxTitleLength).WithMessage(ValidationErrors.MaxLengthExceeded.Message);
+                .MaximumLength(TextValidationRules.MaxTitleLength)
+                .WithMessage(ValidationErrors.MaxLengthExceeded.Message);
 
             // 📌 PlanId must be positive
             RuleFor(x => x.PlanId)
-                .GreaterThan(0).WithMessage(ValidationErrors.RequiredField.Message);
+                .GreaterThan(0)
+                .WithMessage(ValidationErrors.RequiredField.Message);
 
             // 📌 Expected Date must not be in the past
             RuleFor(x => x.ExcepectedDate.Date)
-                .GreaterThanOrEqualTo(DateTime.Today).WithMessage(SessionErrors.ExpectedDateInThePast.Message);
+                .GreaterThanOrEqualTo(DateTime.Today)
+                .WithMessage(SessionErrors.ExpectedDateInThePast.Message);
 
             // 📌 StartTime must be before EndTime
             RuleFor(x => x)
@@ -35,7 +38,9 @@ namespace Drosy.Infrastructure.Validators.SessionValidatiors
                     x.EndTime.Date == x.ExcepectedDate.Date)
                 .WithMessage(SessionErrors.OutsideExpectedDate.Message);
 
-            
+            RuleFor(x => x.Notes)
+                .MaximumLength(TextValidationRules.MaxNotesLength).When(x => x.Notes is not null)
+                .WithMessage(ValidationErrors.MaxLengthExceeded.Message);
         }
     }
 }

--- a/Drosy.Infrastructure/Validators/SessionValidatiors/RescheduleSessionValidator.cs
+++ b/Drosy.Infrastructure/Validators/SessionValidatiors/RescheduleSessionValidator.cs
@@ -1,0 +1,31 @@
+﻿using FluentValidation;
+using Drosy.Application.UseCases.Sessions.DTOs;
+using Drosy.Domain.Shared.ErrorComponents.Sesstions;
+using Drosy.Domain.Shared.System.Validation.Rules;
+using Drosy.Domain.Shared.ErrorComponents.Validation;
+
+namespace Drosy.Infrastructure.Validators.SessionValidatiors
+{
+    public class RescheduleSessionValidator : AbstractValidator<RescheduleSessionDTO>
+    {
+        public RescheduleSessionValidator()
+        {
+            // NewDate must not be in the past
+            RuleFor(x => x.NewDate.Date)
+                .GreaterThanOrEqualTo(DateTime.Today)
+                .WithMessage(SessionErrors.ExpectedDateInThePast.Message);
+
+            // NewStartTime must be before NewEndTime
+            RuleFor(x => x)
+                .Must(x => x.NewStartTime < x.NewEndTime)
+                .WithMessage(SessionErrors.StartAfterEnd.Message);
+
+            // Start/End times must match NewDate
+            RuleFor(x => x)
+                .Must(x =>
+                    x.NewStartTime.Date == x.NewDate.Date &&
+                    x.NewEndTime.Date == x.NewDate.Date)
+                .WithMessage(SessionErrors.OutsideExpectedDate.Message);
+        }
+    }
+}

--- a/Drosy.Tests/Application/Sessions/SessionServiceTests.cs
+++ b/Drosy.Tests/Application/Sessions/SessionServiceTests.cs
@@ -74,7 +74,7 @@ namespace Drosy.Tests.Application.Sessions
         public async Task AddAsync_ValidationTheory(string title, string start, string end, string expected, bool isValid)
         {
             // Arrange
-            var addDto = new AddSessionDTO
+            var addDto = new CreateSessionDTO
             {
                 Title = title,
                 StartTime = DateTime.Parse(start),
@@ -86,13 +86,13 @@ namespace Drosy.Tests.Application.Sessions
             {
                 var resultDto = new SessionDTO { Id = 1, Title = title };
                 _sessionService
-                    .Setup(s => s.CreateAsync(It.Is<AddSessionDTO>(d => d.Title == title), CancellationToken.None))
+                    .Setup(s => s.CreateAsync(It.Is<CreateSessionDTO>(d => d.Title == title), CancellationToken.None))
                     .ReturnsAsync(Result.Success(resultDto));
             }
             else
             {
                 _sessionService
-                    .Setup(s => s.CreateAsync(It.Is<AddSessionDTO>(d => d.Title == title), CancellationToken.None))
+                    .Setup(s => s.CreateAsync(It.Is<CreateSessionDTO>(d => d.Title == title), CancellationToken.None))
                     .ReturnsAsync(Result.Failure<SessionDTO>(CommonErrors.Invalid));
             }
 
@@ -111,5 +111,65 @@ namespace Drosy.Tests.Application.Sessions
                 Assert.NotNull(result.Error);
             }
         }
+
+        [Theory]
+        [InlineData(0, "2025-08-01T09:00:00", "2025-08-01T10:00:00", "2025-08-01", false)]  // Invalid ID
+        [InlineData(1, "2025-08-01T10:30:00", "2025-08-01T09:30:00", "2025-08-01", false)] // StartTime after EndTime
+        [InlineData(1, "2025-08-02T09:00:00", "2025-08-02T10:00:00", "2025-08-01", false)] // Date mismatch
+        [InlineData(1, "2025-08-01T09:00:00", "2025-08-01T10:00:00", "2025-08-01", true)]  // Valid input
+        public async Task RescheduleAsync_ValidationTheory(int sessionId, string start, string end, string expected, bool isValid)
+        {
+            // Arrange
+            var dto = new RescheduleSessionDTO
+            {
+                NewStartTime = DateTime.Parse(start),
+                NewEndTime = DateTime.Parse(end),
+                NewDate = DateTime.Parse(expected)
+            };
+
+            if (isValid)
+            {
+                var sessionResult = new SessionDTO { Id = sessionId, Title = "Updated Session" };
+                _sessionService
+                    .Setup(s => s.RescheduleAsync(
+                        It.Is<int>(id => id == sessionId),
+                        It.Is<RescheduleSessionDTO>(d =>
+                            d.NewStartTime == dto.NewStartTime &&
+                            d.NewEndTime == dto.NewEndTime &&
+                            d.NewDate == dto.NewDate),
+                        CancellationToken.None))
+                    .ReturnsAsync(Result.Success(sessionResult));
+            }
+            else
+            {
+                _sessionService
+                    .Setup(s => s.RescheduleAsync(
+                        It.Is<int>(id => id == sessionId),
+                        It.Is<RescheduleSessionDTO>(d =>
+                            d.NewStartTime == dto.NewStartTime &&
+                            d.NewEndTime == dto.NewEndTime &&
+                            d.NewDate == dto.NewDate),
+                        CancellationToken.None))
+                    .ReturnsAsync(Result.Failure<SessionDTO>(CommonErrors.Invalid));
+            }
+
+            // Act
+            var result = await _sessionService.Object.RescheduleAsync(sessionId, dto, CancellationToken.None);
+
+            // Assert
+            if (isValid)
+            {
+                Assert.True(result.IsSuccess);
+                Assert.NotNull(result.Value);
+                Assert.Equal(sessionId, result.Value.Id);
+            }
+            else
+            {
+                Assert.False(result.IsSuccess);
+                Assert.NotNull(result.Error);
+                Assert.Equal(CommonErrors.Invalid.Code, result.Error.Code);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
…ession

- Added XML comments and ProducesResponseType annotations to CreateAsync, RescheduleAsync, and GetByIdAsync for improved API clarity.
- Introduced 'Notes' property to Session entity and corresponding DTOs (CreateSessionDTO, RescheduleSessionDTO, SessionDTO).
- Updated theory-based unit tests to include Notes field validation in CreateAsync and RescheduleAsync scenarios.

Improves session metadata handling and boosts documentation precision.